### PR TITLE
fix: 修复了 NoticeEvent 与 RequestEvent 中 String 值的 json 解析错误

### DIFF
--- a/src/bot/plugin_builder/event.rs
+++ b/src/bot/plugin_builder/event.rs
@@ -54,8 +54,18 @@ impl NoticeEvent {
         let temp: Value = serde_json::from_str(msg)?;
         let time = temp.get("time").unwrap().as_i64().unwrap();
         let self_id = temp.get("self_id").unwrap().as_i64().unwrap();
-        let post_type = temp.get("post_type").unwrap().to_string();
-        let notice_type = temp.get("notice_type").unwrap().to_string();
+        let post_type = temp
+            .get("post_type")
+            .unwrap()
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        let notice_type = temp
+            .get("notice_type")
+            .unwrap()
+            .as_str()
+            .unwrap_or("")
+            .to_string();
         Ok(NoticeEvent {
             time,
             self_id,
@@ -85,8 +95,18 @@ impl RequestEvent {
         let temp: Value = serde_json::from_str(msg)?;
         let time = temp.get("time").unwrap().as_i64().unwrap();
         let self_id = temp.get("self_id").unwrap().as_i64().unwrap();
-        let post_type = temp.get("post_type").unwrap().to_string();
-        let request_type = temp.get("request_type").unwrap().to_string();
+        let post_type = temp
+            .get("post_type")
+            .unwrap()
+            .as_str()
+            .unwrap_or("")
+            .to_string();
+        let request_type = temp
+            .get("request_type")
+            .unwrap()
+            .as_str()
+            .unwrap_or("")
+            .to_string();
         Ok(RequestEvent {
             time,
             self_id,


### PR DESCRIPTION
将 `post_type`、`sub_type`、`request_type` 的解析语句从

```
temp.get("value_name").unwrap().to_string()
```

更正为

```
temp.get("value_name").unwrap().as_str().unwrap_or("").to_string()`
```

修复了直接使用 `to_string()` 解析值后结果带有双引号的情况，更正后解析出的结果将不再带有双引号