### PR TITLE
sub route ws server support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ env_logger = { version = "0.11", default-features = false, features = [
     "color",
 ], optional = true }
 tokio = { version = "1", features = ["full", "windows-sys"] }
-tokio-tungstenite = "0.26"
+tokio-tungstenite = "0.27.0"
 futures-util = "0.3"
 http = "1"
-toml = "0.8"
-toml_edit = "0.22"
-croner = "2"
+toml = "0.9.5"
+toml_edit = "0.23.3"
+croner = "2.2.0"
 rand = "0.9"
 ahash = "0.8"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ http = "1"
 toml = "0.9.5"
 toml_edit = "0.23.3"
 croner = "2.2.0"
-rand = "0.9"
 ahash = "0.8"
 parking_lot = "0.12"
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -3,7 +3,6 @@ use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Input, Select};
 use parking_lot::RwLock;
 use plugin_builder::Listen;
-use rand::Rng as _;
 #[cfg(feature = "plugin-access-control")]
 use runtimebot::kovi_api::AccessList;
 use serde::{Deserialize, Serialize};
@@ -514,13 +513,9 @@ impl SendApi {
     }
 
     pub fn rand_echo() -> String {
-        let mut rng = rand::rng();
-        let mut s = String::new();
-        s.push_str(&chrono::Utc::now().timestamp().to_string());
-        for _ in 0..10 {
-            s.push(rng.random_range('a'..='z'));
-        }
-        s
+        RandomState::new()
+            .hash_one(chrono::Utc::now().timestamp_micros())
+            .to_string()
     }
 }
 


### PR DESCRIPTION
1. 支持了 "/ws" 等非挂载到 http 根节点的ws服务器
2. 支持了单节点的 websocket 通讯（onebot 规范有定义）
3. 改进了 echo 的生成方式，用 ahash 生成key随机的 randomstate 再基于微妙级时间戳算散列值，最后转为 string