### PR TITLE
添加并为事件实现trait，允许使用泛型处理事件

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "kovi"
 version = "0.12.5"
 authors = ["ThriceCola <thricecola@hotmail.com>"]
-authors = ["ThriceCola <thricecola@hotmail.com>"]
 edition = "2024"
 description = "A OneBot V11 bot plugin framework"
 license = "MPL-2.0"

--- a/src/bot/event.rs
+++ b/src/bot/event.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bot::BotInformation,
+    bot::{BotInformation, message::Message, SendApi},
     types::{ApiAndOneshot, ApiAndRuturn},
 };
 use serde::{Deserialize, Serialize};
@@ -153,6 +153,57 @@ pub trait Event: Any + Send + Sync {
     ) -> Option<Self>
     where
         Self: Sized;
+}
+
+/// 满足此 trait 即可被回复
+pub trait RepliableEvent {
+    fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
+    where
+        T: Serialize;
+
+    #[cfg(not(feature = "cqstring"))]
+    /// 快速回复消息
+    fn reply<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize;
+
+    #[cfg(feature = "cqstring")]
+    /// 快速回复消息
+    fn reply<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize;
+
+    #[cfg(not(feature = "cqstring"))]
+    /// 快速回复消息并且**引用**
+    fn reply_and_quote<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize;
+
+    #[cfg(feature = "cqstring")]
+    /// 快速回复消息并且**引用**
+    fn reply_and_quote<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize;
+
+    #[cfg(feature = "cqstring")]
+    /// 快速回复消息，并且**kovi不进行解析，直接发送此字符串**
+    fn reply_text<T>(&self, msg: T)
+    where
+        String: From<T>,
+        T: Serialize;
+
+    /// 便捷获取文本，如果没有文本则会返回空字符串，如果只需要借用，请使用 `borrow_text()`
+    fn get_text(&self) -> String;
+
+    /// 便捷获取发送者昵称，如果无名字，此处为空字符串
+    fn get_sender_nickname(&self) -> String;
+
+    /// 借用 event 的 text，只是做了一下self.text.as_deref()的包装
+    fn borrow_text(&self) -> Option<&str>;
 }
 
 /// 事件

--- a/src/bot/event.rs
+++ b/src/bot/event.rs
@@ -155,6 +155,13 @@ pub trait Event: Any + Send + Sync {
         Self: Sized;
 }
 
+/// 满足此 trait 即可判断消息来源
+pub trait UniversalMessage {
+    fn is_group(&self) -> bool;
+
+    fn is_private(&self) -> bool;
+}
+
 /// 满足此 trait 即可被回复
 pub trait RepliableEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi

--- a/src/bot/event/admin_msg_event.rs
+++ b/src/bot/event/admin_msg_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::MsgEvent;
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
-use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent, UniversalMessage};
 use crate::bot::runtimebot::{CanSendApi, send_api_request_with_forget};
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -139,11 +139,63 @@ where
 }
 
 impl AdminMsgEvent {
-    pub fn is_group(&self) -> bool {
+    fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
+    where
+        T: Serialize,
+    { RepliableEvent::reply_builder(self, msg, auto_escape) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(feature = "cqstring")]
+    pub fn reply<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply_and_quote<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_and_quote<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_text<T>(&self, msg: T)
+    where
+        String: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_text(self, msg) }
+
+    pub fn get_text(&self) -> String { RepliableEvent::get_text(self) }
+
+    pub fn get_sender_nickname(&self) -> String { RepliableEvent::get_sender_nickname(self) }
+
+    pub fn borrow_text(&self) -> Option<&str> { RepliableEvent::borrow_text(self) }
+
+    pub fn is_group(&self) -> bool { UniversalMessage::is_group(self) }
+    
+    pub fn is_private(&self) -> bool { UniversalMessage::is_private(self) }
+}
+
+impl UniversalMessage for AdminMsgEvent {
+    fn is_group(&self) -> bool {
         self.group_id.is_some()
     }
 
-    pub fn is_private(&self) -> bool {
+    fn is_private(&self) -> bool {
         self.group_id.is_none()
     }
 }

--- a/src/bot/event/admin_msg_event.rs
+++ b/src/bot/event/admin_msg_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::MsgEvent;
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
-use crate::bot::plugin_builder::event::{Event, PostType};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
 use crate::bot::runtimebot::{CanSendApi, send_api_request_with_forget};
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -139,6 +139,16 @@ where
 }
 
 impl AdminMsgEvent {
+    pub fn is_group(&self) -> bool {
+        self.group_id.is_some()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.group_id.is_none()
+    }
+}
+
+impl RepliableEvent for AdminMsgEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where
         T: Serialize,
@@ -168,7 +178,7 @@ impl AdminMsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -191,7 +201,7 @@ impl AdminMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -213,7 +223,7 @@ impl AdminMsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -237,7 +247,7 @@ impl AdminMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -260,7 +270,7 @@ impl AdminMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息，并且**kovi不进行解析，直接发送此字符串**
-    pub fn reply_text<T>(&self, msg: T)
+    fn reply_text<T>(&self, msg: T)
     where
         String: From<T>,
         T: Serialize,
@@ -280,7 +290,7 @@ impl AdminMsgEvent {
     }
 
     /// 便捷获取文本，如果没有文本则会返回空字符串，如果只需要借用，请使用 `borrow_text()`
-    pub fn get_text(&self) -> String {
+    fn get_text(&self) -> String {
         match self.text.clone() {
             Some(v) => v,
             None => "".to_string(),
@@ -288,7 +298,7 @@ impl AdminMsgEvent {
     }
 
     /// 便捷获取发送者昵称，如果无名字，此处为空字符串
-    pub fn get_sender_nickname(&self) -> String {
+    fn get_sender_nickname(&self) -> String {
         if let Some(v) = &self.sender.nickname {
             v.clone()
         } else {
@@ -297,16 +307,8 @@ impl AdminMsgEvent {
     }
 
     /// 借用 event 的 text，只是做了一下self.text.as_deref()的包装
-    pub fn borrow_text(&self) -> Option<&str> {
+    fn borrow_text(&self) -> Option<&str> {
         self.text.as_deref()
-    }
-
-    pub fn is_group(&self) -> bool {
-        self.group_id.is_some()
-    }
-
-    pub fn is_private(&self) -> bool {
-        self.group_id.is_none()
     }
 }
 

--- a/src/bot/event/group_msg_event.rs
+++ b/src/bot/event/group_msg_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::MsgEvent;
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
-use crate::bot::plugin_builder::event::{Event, PostType};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
 use crate::bot::runtimebot::{CanSendApi, send_api_request_with_forget};
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -138,7 +138,7 @@ where
     }
 }
 
-impl GroupMsgEvent {
+impl RepliableEvent for  GroupMsgEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where
         T: Serialize,
@@ -156,7 +156,7 @@ impl GroupMsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -175,7 +175,7 @@ impl GroupMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -193,7 +193,7 @@ impl GroupMsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -212,7 +212,7 @@ impl GroupMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -230,7 +230,7 @@ impl GroupMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息，并且**kovi不进行解析，直接发送此字符串**
-    pub fn reply_text<T>(&self, msg: T)
+    fn reply_text<T>(&self, msg: T)
     where
         String: From<T>,
         T: Serialize,
@@ -246,7 +246,7 @@ impl GroupMsgEvent {
     }
 
     /// 便捷获取文本，如果没有文本则会返回空字符串，如果只需要借用，请使用 `borrow_text()`
-    pub fn get_text(&self) -> String {
+    fn get_text(&self) -> String {
         match self.text.clone() {
             Some(v) => v,
             None => "".to_string(),
@@ -254,7 +254,7 @@ impl GroupMsgEvent {
     }
 
     /// 便捷获取发送者昵称，如果无名字，此处为空字符串
-    pub fn get_sender_nickname(&self) -> String {
+    fn get_sender_nickname(&self) -> String {
         if let Some(v) = &self.sender.nickname {
             v.clone()
         } else {
@@ -263,7 +263,7 @@ impl GroupMsgEvent {
     }
 
     /// 借用 event 的 text，只是做了一下self.text.as_deref()的包装
-    pub fn borrow_text(&self) -> Option<&str> {
+    fn borrow_text(&self) -> Option<&str> {
         self.text.as_deref()
     }
 }

--- a/src/bot/event/group_msg_event.rs
+++ b/src/bot/event/group_msg_event.rs
@@ -138,7 +138,55 @@ where
     }
 }
 
-impl RepliableEvent for  GroupMsgEvent {
+impl GroupMsgEvent {
+    fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
+    where
+        T: Serialize,
+    { RepliableEvent::reply_builder(self, msg, auto_escape) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(feature = "cqstring")]
+    pub fn reply<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply_and_quote<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_and_quote<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_text<T>(&self, msg: T)
+    where
+        String: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_text(self, msg) }
+
+    pub fn get_text(&self) -> String { RepliableEvent::get_text(self) }
+
+    pub fn get_sender_nickname(&self) -> String { RepliableEvent::get_sender_nickname(self) }
+
+    pub fn borrow_text(&self) -> Option<&str> { RepliableEvent::borrow_text(self) }
+}
+
+impl RepliableEvent for GroupMsgEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where
         T: Serialize,

--- a/src/bot/event/msg_event.rs
+++ b/src/bot/event/msg_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
 use crate::bot::message::cq_to_arr_inner;
-use crate::bot::plugin_builder::event::{Event, PostType};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
 use crate::bot::runtimebot::{CanSendApi, send_api_request_with_forget};
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -326,6 +326,16 @@ where
 }
 
 impl MsgEvent {
+    pub fn is_group(&self) -> bool {
+        self.group_id.is_some()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.group_id.is_none()
+    }
+}
+
+impl RepliableEvent for MsgEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where
         T: Serialize,
@@ -355,7 +365,7 @@ impl MsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -378,7 +388,7 @@ impl MsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -400,7 +410,7 @@ impl MsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -424,7 +434,7 @@ impl MsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -447,7 +457,7 @@ impl MsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息，并且**kovi不进行解析，直接发送此字符串**
-    pub fn reply_text<T>(&self, msg: T)
+    fn reply_text<T>(&self, msg: T)
     where
         String: From<T>,
         T: Serialize,
@@ -467,7 +477,7 @@ impl MsgEvent {
     }
 
     /// 便捷获取文本，如果没有文本则会返回空字符串，如果只需要借用，请使用 `borrow_text()`
-    pub fn get_text(&self) -> String {
+    fn get_text(&self) -> String {
         match self.text.clone() {
             Some(v) => v,
             None => "".to_string(),
@@ -475,7 +485,7 @@ impl MsgEvent {
     }
 
     /// 便捷获取发送者昵称，如果无名字，此处为空字符串
-    pub fn get_sender_nickname(&self) -> String {
+    fn get_sender_nickname(&self) -> String {
         if let Some(v) = &self.sender.nickname {
             v.clone()
         } else {
@@ -484,16 +494,8 @@ impl MsgEvent {
     }
 
     /// 借用 event 的 text，只是做了一下self.text.as_deref()的包装
-    pub fn borrow_text(&self) -> Option<&str> {
+    fn borrow_text(&self) -> Option<&str> {
         self.text.as_deref()
-    }
-
-    pub fn is_group(&self) -> bool {
-        self.group_id.is_some()
-    }
-
-    pub fn is_private(&self) -> bool {
-        self.group_id.is_none()
     }
 }
 

--- a/src/bot/event/msg_send_from_server_event.rs
+++ b/src/bot/event/msg_send_from_server_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::MsgEvent;
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
-use crate::bot::plugin_builder::event::{Event, PostType};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
 use crate::bot::runtimebot::{CanSendApi, send_api_request_with_forget};
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -142,6 +142,16 @@ where
 }
 
 impl MsgSendFromServerEvent {
+    pub fn is_group(&self) -> bool {
+        self.group_id.is_some()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.group_id.is_none()
+    }
+}
+
+impl RepliableEvent for MsgSendFromServerEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where
         T: Serialize,
@@ -171,7 +181,7 @@ impl MsgSendFromServerEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -194,7 +204,7 @@ impl MsgSendFromServerEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -216,7 +226,7 @@ impl MsgSendFromServerEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -240,7 +250,7 @@ impl MsgSendFromServerEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -263,7 +273,7 @@ impl MsgSendFromServerEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息，并且**kovi不进行解析，直接发送此字符串**
-    pub fn reply_text<T>(&self, msg: T)
+    fn reply_text<T>(&self, msg: T)
     where
         String: From<T>,
         T: Serialize,
@@ -283,7 +293,7 @@ impl MsgSendFromServerEvent {
     }
 
     /// 便捷获取文本，如果没有文本则会返回空字符串，如果只需要借用，请使用 `borrow_text()`
-    pub fn get_text(&self) -> String {
+    fn get_text(&self) -> String {
         match self.text.clone() {
             Some(v) => v,
             None => "".to_string(),
@@ -291,7 +301,7 @@ impl MsgSendFromServerEvent {
     }
 
     /// 便捷获取发送者昵称，如果无名字，此处为空字符串
-    pub fn get_sender_nickname(&self) -> String {
+    fn get_sender_nickname(&self) -> String {
         if let Some(v) = &self.sender.nickname {
             v.clone()
         } else {
@@ -300,16 +310,8 @@ impl MsgSendFromServerEvent {
     }
 
     /// 借用 event 的 text，只是做了一下self.text.as_deref()的包装
-    pub fn borrow_text(&self) -> Option<&str> {
+    fn borrow_text(&self) -> Option<&str> {
         self.text.as_deref()
-    }
-
-    pub fn is_group(&self) -> bool {
-        self.group_id.is_some()
-    }
-
-    pub fn is_private(&self) -> bool {
-        self.group_id.is_none()
     }
 }
 

--- a/src/bot/event/msg_send_from_server_event.rs
+++ b/src/bot/event/msg_send_from_server_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::MsgEvent;
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
-use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent, UniversalMessage};
 use crate::bot::runtimebot::{CanSendApi, send_api_request_with_forget};
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -142,11 +142,63 @@ where
 }
 
 impl MsgSendFromServerEvent {
-    pub fn is_group(&self) -> bool {
+    fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
+    where
+        T: Serialize,
+    { RepliableEvent::reply_builder(self, msg, auto_escape) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(feature = "cqstring")]
+    pub fn reply<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply_and_quote<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_and_quote<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_text<T>(&self, msg: T)
+    where
+        String: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_text(self, msg) }
+
+    pub fn get_text(&self) -> String { RepliableEvent::get_text(self) }
+
+    pub fn get_sender_nickname(&self) -> String { RepliableEvent::get_sender_nickname(self) }
+
+    pub fn borrow_text(&self) -> Option<&str> { RepliableEvent::borrow_text(self) }
+
+    pub fn is_group(&self) -> bool { UniversalMessage::is_group(self) }
+    
+    pub fn is_private(&self) -> bool { UniversalMessage::is_private(self) }
+}
+
+impl UniversalMessage for MsgSendFromServerEvent {
+    fn is_group(&self) -> bool {
         self.group_id.is_some()
     }
 
-    pub fn is_private(&self) -> bool {
+    fn is_private(&self) -> bool {
         self.group_id.is_none()
     }
 }

--- a/src/bot/event/private_msg_event.rs
+++ b/src/bot/event/private_msg_event.rs
@@ -2,7 +2,7 @@ use super::{Anonymous, Sender};
 use crate::MsgEvent;
 use crate::bot::BotInformation;
 use crate::bot::event::InternalEvent;
-use crate::bot::plugin_builder::event::{Event, PostType};
+use crate::bot::plugin_builder::event::{Event, PostType, RepliableEvent};
 use crate::bot::runtimebot::send_api_request_with_forget;
 use crate::error::EventBuildError;
 use crate::types::ApiAndOneshot;
@@ -135,7 +135,7 @@ where
     }
 }
 
-impl PrivateMsgEvent {
+impl RepliableEvent for PrivateMsgEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where
         T: Serialize,
@@ -153,7 +153,7 @@ impl PrivateMsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -171,7 +171,7 @@ impl PrivateMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息
-    pub fn reply<T>(&self, msg: T)
+    fn reply<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -188,7 +188,7 @@ impl PrivateMsgEvent {
 
     #[cfg(not(feature = "cqstring"))]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         Message: From<T>,
         T: Serialize,
@@ -207,7 +207,7 @@ impl PrivateMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息并且**引用**
-    pub fn reply_and_quote<T>(&self, msg: T)
+    fn reply_and_quote<T>(&self, msg: T)
     where
         CQMessage: From<T>,
         T: Serialize,
@@ -225,7 +225,7 @@ impl PrivateMsgEvent {
 
     #[cfg(feature = "cqstring")]
     /// 快速回复消息，并且**kovi不进行解析，直接发送此字符串**
-    pub fn reply_text<T>(&self, msg: T)
+    fn reply_text<T>(&self, msg: T)
     where
         String: From<T>,
         T: Serialize,
@@ -240,7 +240,7 @@ impl PrivateMsgEvent {
     }
 
     /// 便捷获取文本，如果没有文本则会返回空字符串，如果只需要借用，请使用 `borrow_text()`
-    pub fn get_text(&self) -> String {
+    fn get_text(&self) -> String {
         match self.text.clone() {
             Some(v) => v,
             None => "".to_string(),
@@ -248,7 +248,7 @@ impl PrivateMsgEvent {
     }
 
     /// 便捷获取发送者昵称，如果无名字，此处为空字符串
-    pub fn get_sender_nickname(&self) -> String {
+    fn get_sender_nickname(&self) -> String {
         if let Some(v) = &self.sender.nickname {
             v.clone()
         } else {
@@ -257,7 +257,7 @@ impl PrivateMsgEvent {
     }
 
     /// 借用 event 的 text，只是做了一下self.text.as_deref()的包装
-    pub fn borrow_text(&self) -> Option<&str> {
+    fn borrow_text(&self) -> Option<&str> {
         self.text.as_deref()
     }
 }

--- a/src/bot/event/private_msg_event.rs
+++ b/src/bot/event/private_msg_event.rs
@@ -135,6 +135,54 @@ where
     }
 }
 
+impl PrivateMsgEvent {
+    fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
+    where
+        T: Serialize,
+    { RepliableEvent::reply_builder(self, msg, auto_escape) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(feature = "cqstring")]
+    pub fn reply<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply(self, msg) }
+
+    #[cfg(not(feature = "cqstring"))]
+    pub fn reply_and_quote<T>(&self, msg: T)
+    where
+        Message: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_and_quote<T>(&self, msg: T)
+    where
+        CQMessage: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_and_quote(self, msg); }
+
+    #[cfg(feature = "cqstring")]
+    fn reply_text<T>(&self, msg: T)
+    where
+        String: From<T>,
+        T: Serialize,
+    { RepliableEvent::reply_text(self, msg) }
+
+    pub fn get_text(&self) -> String { RepliableEvent::get_text(self) }
+
+    pub fn get_sender_nickname(&self) -> String { RepliableEvent::get_sender_nickname(self) }
+
+    pub fn borrow_text(&self) -> Option<&str> { RepliableEvent::borrow_text(self) }
+}
+
 impl RepliableEvent for PrivateMsgEvent {
     fn reply_builder<T>(&self, msg: T, auto_escape: bool) -> SendApi
     where


### PR DESCRIPTION
为可回复的事件与实现了RepliableEvent trait
为可判断是私聊/群聊的事件实现了UniversalMessage trait
在事件方法里包装了一层trait方法

不同的事件监听器现在可以复用比如同一个事件处理器

兼容旧的调用方法